### PR TITLE
Scrum 68 update user backend to support multiple groups

### DIFF
--- a/auth/JWTBearer.py
+++ b/auth/JWTBearer.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Any
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -24,7 +24,7 @@ class JWKS(BaseModel):
 class JWTAuthorizationCredentials(BaseModel):
     jwt_token: str
     header: dict[str, str]
-    claims: dict[str, str]
+    claims: dict[str, Any]
     signature: str
     message: str
 
@@ -187,7 +187,6 @@ class JWTBearer(HTTPBearer):
 
         # Remove unnecessary fields from claims
         claims.pop("version", None)
-        claims.pop("cognito:groups", None)
 
         # Convert timestamps to strings
         for claim in ["auth_time", "iat", "exp"]:

--- a/auth/auth.py
+++ b/auth/auth.py
@@ -22,7 +22,7 @@ auth = JWTBearer(jwks)
 
 async def get_current_user(
     credentials: JWTAuthorizationCredentials = Depends(auth),
-) -> str:
+) -> dict:
     """
     Get the current user from the JWT token.
 
@@ -31,6 +31,8 @@ async def get_current_user(
     """
 
     try:
-        return credentials.claims["username"]
+        username = credentials.claims["username"]
+        groups = credentials.claims.get("cognito:groups", [])
+        return {"username": username, "groups": groups}
     except KeyError:
         HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Username missing")

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -70,14 +70,11 @@ async def current_user(
     :param db: Database session.
     :return: User object if found, otherwise raise an HTTPException
     """
-    print(credentials)
-    admin = "admin" in credentials["groups"]
-    user = get_user(username=credentials["username"], db=db)
-    user_dict = user.__dict__
-    user_dict["admin"] = admin
+    user = get_user(username=credentials["username"], db=db).__dict__
+    user["admin"] = "admin" in credentials["groups"]
     return JSONResponse(
         status_code=200,
-        content=jsonable_encoder(user_dict),
+        content=jsonable_encoder(user),
     )
 
 

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -61,7 +61,7 @@ async def login(code: str, db: Session = Depends(get_db)):
 
 @router.get("/auth/me", dependencies=[Depends(auth)])
 async def current_user(
-    username: str = Depends(get_current_user), db: Session = Depends(get_db)
+    credentials: dict = Depends(get_current_user), db: Session = Depends(get_db)
 ):
     """
     Function that returns the current user.
@@ -70,9 +70,14 @@ async def current_user(
     :param db: Database session.
     :return: User object if found, otherwise raise an HTTPException
     """
+    print(credentials)
+    admin = "admin" in credentials["groups"]
+    user = get_user(username=credentials["username"], db=db)
+    user_dict = user.__dict__
+    user_dict["admin"] = admin
     return JSONResponse(
         status_code=200,
-        content=jsonable_encoder(get_user(username=username, db=db)),
+        content=jsonable_encoder(user_dict),
     )
 
 


### PR DESCRIPTION
This pull request includes several changes to the authentication system, specifically focusing on JWT handling and user retrieval. The most important changes include updating type annotations, modifying the structure of JWT claims, and enhancing the user retrieval process to include user groups.

### Type Annotations and JWT Claims:

* [`auth/JWTBearer.py`](diffhunk://#diff-c1e524ac5a1555a2cd7202dc19c35dede7112f5397123588e94e7b0ef1e122f7L3-R3): Updated type annotations to include `Any` for claims to allow for more flexible data types. [[1]](diffhunk://#diff-c1e524ac5a1555a2cd7202dc19c35dede7112f5397123588e94e7b0ef1e122f7L3-R3) [[2]](diffhunk://#diff-c1e524ac5a1555a2cd7202dc19c35dede7112f5397123588e94e7b0ef1e122f7L27-R27)

### User Retrieval Enhancements:

* [`auth/auth.py`](diffhunk://#diff-971661e1ab288c137f644c2317ed914fb5522e0ef3b430cbdc1c58a6af826972L25-R25): Modified the `get_current_user` function to return a dictionary containing both the username and user groups instead of just the username. [[1]](diffhunk://#diff-971661e1ab288c137f644c2317ed914fb5522e0ef3b430cbdc1c58a6af826972L25-R25) [[2]](diffhunk://#diff-971661e1ab288c137f644c2317ed914fb5522e0ef3b430cbdc1c58a6af826972L34-R36)
* [`routers/auth.py`](diffhunk://#diff-edcfd80d7c5e51c05a01f8fc4079088fe44e05a58382b801009203aca3c8ff3dL64-R64): Updated the `current_user` endpoint to use the new dictionary structure from `get_current_user` and added logic to include an `admin` flag based on user groups. [[1]](diffhunk://#diff-edcfd80d7c5e51c05a01f8fc4079088fe44e05a58382b801009203aca3c8ff3dL64-R64) [[2]](diffhunk://#diff-edcfd80d7c5e51c05a01f8fc4079088fe44e05a58382b801009203aca3c8ff3dR73-R77)

### Removal of Unnecessary Claims:

* [`auth/JWTBearer.py`](diffhunk://#diff-c1e524ac5a1555a2cd7202dc19c35dede7112f5397123588e94e7b0ef1e122f7L190): Removed the `cognito:groups` claim from the claims dictionary during JWT creation, as it is now handled separately.